### PR TITLE
README: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ nodes:
     input: stripe_charges
   - key: stripe_customer_lifetime_sales
     snap: customer_lifetime_sales
-    input: accumulated_stripe_charge
+    input: accumulated_stripe_charges
 """)
 
 print(g)


### PR DESCRIPTION
Currently, the example in readme throws

```
KeyError: 'accumulated_stripe_charge'
```

when trying to run the graph. There is a typo in a node name.